### PR TITLE
Revert: re-enable automatic idle and breathing motions

### DIFF
--- a/src/lib/renderer/Live2DRenderer.js
+++ b/src/lib/renderer/Live2DRenderer.js
@@ -93,7 +93,7 @@ export class Live2DRenderer extends BaseRenderer {
     url += (url.includes('?') ? '&' : '?') + 't=' + Date.now();
     const { live2d: { Live2DModel } } = PIXI;
     try {
-      const model = await Live2DModel.from(url, { autoInteract: false, idleMotionGroup: 'None' });
+      const model = await Live2DModel.from(url, { autoInteract: false });
       if (this.#disposed) {
         model.destroy();
         return;
@@ -130,9 +130,6 @@ export class Live2DRenderer extends BaseRenderer {
       model.position.set(w * 0.5, h * 0.5);
       if (!this.#isExport && this.#app && this.#app.stage) {
         this.#app.stage.addChild(model);
-      }
-      if (model.internalModel && model.internalModel.breath) {
-        model.internalModel.breath = null;
       }
       const animations = await this.#filterAnimations();
       if (this.#disposed || !this.#model) return;


### PR DESCRIPTION
This PR reverts the changes from commit b89196d that disabled automatic idle and breathing motions in Live2D models.

## Changes
- Removed `idleMotionGroup: 'None'` from Live2DModel initialization
- Removed the code that sets `model.internalModel.breath` to null

## Related Issue
Reverts fix for #11 (请问如何能够取消live2d的自动呼吸和摇头动作？)

This restores the original Live2D model behavior where automatic idle animations and breathing motions are enabled.